### PR TITLE
自動更新機能

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -4,7 +4,9 @@ $(function() {
   function buildHTML(message){
     if (message.image) {
       // 画像が添付されていた場合
-      let html = `<div class="chat-items">
+      let html = // カスタムデータにメッセージのidを設定し、自動更新機能に利用する
+                  `
+                  <div class="chat-items", data-message-id=${message.id}>
                     <div class="chat-items__top">
                       <div class="chat-items__top--black">
                         ${message.user_name}
@@ -23,7 +25,7 @@ $(function() {
       return html
     } else {
       // 画像が添付されていなかった場合
-      let html = `<div class="chat-items">
+      let html = `<div class="chat-items", data-message-id=${message.id}>
                     <div class="chat-items__top">
                       <div class="chat-items__top--black">
                         ${message.user_name}
@@ -68,4 +70,37 @@ $(function() {
       alert("メッセージ送信に失敗しました");
     });
   });
+
+
+  //自動更新機能の実装
+  let reloadMessages = function() {
+    let last_message_id = $('.chat-items:last').data('message-id');
+    $.ajax({
+      url: 'api/messages',  //ここはよくわからないので後で質問する!!
+      type: 'GET',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        // 追加するHTMLの入れ物を作る
+        let insertHTML = '';
+        // 配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        })
+        // メッセージが入ったHTMLに、入れ物ごと追加
+        $('.chat-main__message-list').append(insertHTML);
+        $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    })
+  }
+
+  //urlがgroups/数字/messagesとマッチする場合のみ、7秒ごとにreloadMessagesを動かす
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 })

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -54,6 +54,8 @@ $mainWhiteColor: #ffffff;
     }
     /*サイドバー下部分の修飾*/
     &__group-list {
+      height: calc(100vh - 100px);
+      overflow: scroll;
       .body-items {
         display: block;
         width: 260px;

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,8 @@
+#名前空間をApiに指定したクラス名をつける
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i  #jsファイル、ajaxのdataで送信したので取得できる
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.chat-items
+.chat-items{data: {message: {id: message.id}}}
   .chat-items__top
     .chat-items__top--black
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content @message.content
 json.image  @message.image_url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.user_name  @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
グループのメッセージ画面における自動更新機能を実装。
新規にcontroller/api直下に`messages_controller.rb`、views/api/messages直下に`index.json.jbuilder`ファイルを作成。`message.js`,`_message.html.haml`,`create.json.jbuilder`,`routes.rb`に記述を追加することで自動更新機能を実装した。
また、`_messages.scss`の記述を変更して、グループ一覧のスクロールが出来るようにした。

# Why
異なるユーザー間でリロードをしなくても他ユーザーの投稿が反映されるようにするため。

# 疑問点
- 2画面でchat-spaceを操作するさい、それぞれ別々のユーザーでログインをするとエラーが発生するが問題ないのか。
- ajaxのurlの指定方法について、`url: "api/messages"`と記述することでlocalhost:3000/group/:id/api/messagesにリクエストを送っているが、もし`url: /api/messages`と記述すればlocalhost:3000/api/messagesにリクエストが行くという認識で間違いないか。